### PR TITLE
Add initial unit testing environment using Catch2 v3 #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore the 'build' directory and all of its contents.
 build/
+build_tests/

--- a/build.bat
+++ b/build.bat
@@ -4,8 +4,17 @@ REM g++ -std=c++17 src/VaultManager.cpp src/CredentialManager.cpp src/CLI.cpp sr
 REM Cmake Build commands
 REM cmake -G "MinGW Makefiles" -S . -B build
 
+REM APP Build
 cmake -G Ninja -S . -B build
 cmake --build build
 
+Rem unit tests build
+cmake -S tests -G Ninja -B build_tests
+cmake --build build_tests
+
 REM run application
 .\build\PasswordManager.exe
+
+REM run unit testing
+cd build_tests
+ctest --output-on-failure

--- a/include/CredentialManager.h
+++ b/include/CredentialManager.h
@@ -9,10 +9,10 @@
 class CredentialManager : public ICredentialService {
 private:
     std::unordered_map<std::string, CredentialData> storage_;
-    std::shared_ptr<VaultManager> vault_;
+    std::shared_ptr<IVaultManager> vault_;
 
 public:
-    explicit CredentialManager(std::shared_ptr<VaultManager> vault);
+    explicit CredentialManager(std::shared_ptr<IVaultManager> vault);
 
     bool addCredential(const std::string& service, const CredentialData& data) override;
     std::optional<CredentialData> getCredential(const std::string& service) const override;

--- a/include/IVaultManager.h
+++ b/include/IVaultManager.h
@@ -1,0 +1,14 @@
+#ifndef I_VAULT_MANAGER_H
+#define I_VAULT_MANAGER_H
+
+#include <unordered_map>
+#include "CredentialData.h"
+
+class IVaultManager {
+public:
+    virtual ~IVaultManager() = default;
+    virtual bool save(const std::unordered_map<std::string, CredentialData>& storage) = 0;
+    virtual std::unordered_map<std::string, CredentialData> load() = 0;
+};
+
+#endif

--- a/include/VaultManager.h
+++ b/include/VaultManager.h
@@ -4,8 +4,9 @@
 #include <string>
 #include <unordered_map>
 #include "CredentialData.h"
+#include "IVaultManager.h"
 
-class VaultManager {
+class VaultManager : public IVaultManager  {
 private:
     std::string filePath_;
 
@@ -14,9 +15,8 @@ private:
 
 public:
     explicit VaultManager(const std::string& filePath);
-
-    bool save(const std::unordered_map<std::string, CredentialData>& storage);
-    std::unordered_map<std::string, CredentialData> load();
+    bool save(const std::unordered_map<std::string, CredentialData>& storage) override;
+    std::unordered_map<std::string, CredentialData> load() override;
 };
 
 #endif // VAULT_MANAGER_H

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -1,6 +1,6 @@
 #include "CredentialManager.h"
 
-CredentialManager::CredentialManager(std::shared_ptr<VaultManager> vault)
+CredentialManager::CredentialManager(std::shared_ptr<IVaultManager> vault)
     : vault_(std::move(vault)) {
     storage_ = vault_->load();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,95 @@
+cmake_minimum_required(VERSION 3.15)
+project(PasswordManager_UnitTests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ---- Paths ----
+set(PROJECT_ROOT_DIR ${CMAKE_SOURCE_DIR}/..)       # since this file is in project_root/tests/
+set(PROJECT_INCLUDE_DIR ${PROJECT_ROOT_DIR}/include)
+set(PROJECT_SRC_DIR ${PROJECT_ROOT_DIR}/src)
+set(TESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# ---- Catch2 submodule (thirdparty/catch2) ----
+# EXCLUDE_FROM_ALL so it's not built automatically unless used
+add_subdirectory(${PROJECT_ROOT_DIR}/thirdparty/catch2 ${CMAKE_BINARY_DIR}/catch2 EXCLUDE_FROM_ALL)
+
+# Enable CTest integration
+enable_testing()
+
+# ---------------------------
+# Helper function: add one unit test target
+# ---------------------------
+function(add_unit_test TARGET_NAME)
+    cmake_parse_arguments(UT "" "UNIT_SRC" "TEST_SRCS;MOCK_DIR" ${ARGN})
+
+    # Check arguments
+    if(NOT UT_UNIT_SRC)
+        message(FATAL_ERROR "add_unit_test: UNIT_SRC is required for target ${TARGET_NAME}")
+    endif()
+    if(NOT UT_TEST_SRCS)
+        message(FATAL_ERROR "add_unit_test: TEST_SRCS is required for target ${TARGET_NAME}")
+    endif()
+
+    # Compose absolute paths
+    set(unit_src_path ${PROJECT_ROOT_DIR}/${UT_UNIT_SRC})
+
+    # Collect test sources (relative to tests dir)
+    set(test_files)
+    foreach(t IN LISTS UT_TEST_SRCS)
+        list(APPEND test_files ${TESTS_DIR}/${t})
+    endforeach()
+
+    # Collect mocks (optional)
+    set(mock_files)
+    if(UT_MOCK_DIR)
+        file(GLOB mock_files ${TESTS_DIR}/${UT_MOCK_DIR}/*.cpp)
+    endif()
+
+    # Define the test executable
+    add_executable(${TARGET_NAME}
+        ${unit_src_path}
+        ${test_files}
+        ${mock_files}
+    )
+
+    # Include directories
+    target_include_directories(${TARGET_NAME} PRIVATE
+        ${PROJECT_INCLUDE_DIR}
+        ${TESTS_DIR}
+    )
+    if(UT_MOCK_DIR)
+        target_include_directories(${TARGET_NAME} PRIVATE ${TESTS_DIR}/${UT_MOCK_DIR})
+    endif()
+
+    # Link against Catch2 (Catch2 provides main)
+    target_link_libraries(${TARGET_NAME} PRIVATE Catch2::Catch2WithMain)
+
+    # Register test with CTest
+    add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
+endfunction()
+
+# ---------------------------
+# Per-module unit tests
+# ---------------------------
+
+# ✅ CredentialManager unit test
+add_unit_test(test_credential_manager
+    UNIT_SRC src/CredentialManager.cpp
+    TEST_SRCS "credential_manager/test_credential_manager.cpp"
+    MOCK_DIR "credential_manager/mocks"
+)
+
+#VaultManager test
+add_unit_test(test_vault_manager
+    UNIT_SRC src/VaultManager.cpp
+    TEST_SRCS "vault_manager/test_vault_manager.cpp"
+    MOCK_DIR "vault_manager/mocks"
+)
+
+# Example: CLI test (uncomment when ready)
+# add_unit_test(test_cli
+#     UNIT_SRC src/CLI.cpp
+#     TEST_SRCS "cli/test_cli.cpp"
+#     MOCK_DIR "cli/mocks"
+# )

--- a/tests/credential_manager/mocks/mock_vault_manager.cpp
+++ b/tests/credential_manager/mocks/mock_vault_manager.cpp
@@ -1,0 +1,11 @@
+#include <unordered_map>
+#include "IVaultManager.h"
+#include"mock_vault_manager.h"
+
+
+    bool MockVaultManager::save(const std::unordered_map<std::string, CredentialData>& storage)  {
+        return true; // no-op
+    }
+    std::unordered_map<std::string, CredentialData> MockVaultManager::load()  {
+        return {}; // return empty mock data
+    }

--- a/tests/credential_manager/mocks/mock_vault_manager.h
+++ b/tests/credential_manager/mocks/mock_vault_manager.h
@@ -1,0 +1,20 @@
+#ifndef MOCK_VAULT_MANAGER_H
+#define MOCK_VAULT_MANAGER_H
+
+#include <unordered_map>
+#include <string>
+#include <memory>
+#include "IVaultManager.h"
+#include "CredentialData.h"
+
+class MockVaultManager : public IVaultManager {
+public:
+    MockVaultManager() = default;
+    ~MockVaultManager() override = default;
+    bool save(const std::unordered_map<std::string, CredentialData>& storage) override;
+    std::unordered_map<std::string, CredentialData> load() override;
+
+    std::unordered_map<std::string, CredentialData> storedData;
+};
+
+#endif // MOCK_VAULT_MANAGER_H

--- a/tests/credential_manager/test_credential_manager.cpp
+++ b/tests/credential_manager/test_credential_manager.cpp
@@ -1,0 +1,18 @@
+#include <catch2/catch_test_macros.hpp>
+#include "CredentialManager.h"
+#include "mock_vault_manager.h"
+#include"IVaultManager.h"
+class MockVaultManager;
+TEST_CASE("CredentialManager adds and retrieves credentials", "[CredentialManager]") {
+    //auto mockVault = std::make_shared<VaultManager>("vault.dat");
+    auto mockVault = std::make_shared<MockVaultManager>();
+    CredentialManager manager(mockVault);
+
+    CredentialData data{"user", "pass"};
+    REQUIRE(manager.addCredential("gmail", data));
+
+    auto retrieved = manager.getCredential("gmail");
+    REQUIRE(retrieved.has_value());
+    REQUIRE(retrieved->username == "user");
+    REQUIRE(retrieved->password == "pass");
+}

--- a/tests/vault_manager/mocks/mock_dependencies.cpp
+++ b/tests/vault_manager/mocks/mock_dependencies.cpp
@@ -1,0 +1,5 @@
+//Not needed
+
+void dummy(){
+    return;
+}

--- a/tests/vault_manager/mocks/mock_dependencies.h
+++ b/tests/vault_manager/mocks/mock_dependencies.h
@@ -1,0 +1,1 @@
+//Do Nothing, just to keep the folder strucutre, maybe needed later in the future

--- a/tests/vault_manager/test_vault_manager.cpp
+++ b/tests/vault_manager/test_vault_manager.cpp
@@ -1,0 +1,37 @@
+#include <catch2/catch_test_macros.hpp>
+#include "VaultManager.h"
+#include "CredentialData.h"
+#include <fstream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+TEST_CASE("VaultManager saves and loads correctly", "[VaultManager]") {
+    std::string testFile = "test_vault.txt";
+
+    // Remove file if it exists from previous runs
+    if (fs::exists(testFile)) fs::remove(testFile);
+
+    VaultManager manager(testFile);
+
+    // Prepare test data
+    std::unordered_map<std::string, CredentialData> data = {
+        {"gmail", {"user1", "pass1"}},
+        {"github", {"user2", "pass2"}}
+    };
+
+    // Test saving
+    REQUIRE(manager.save(data));
+
+    // Test loading
+    auto loaded = manager.load();
+
+    REQUIRE(loaded.size() == 2);
+    REQUIRE(loaded["gmail"].username == "user1");
+    REQUIRE(loaded["gmail"].password == "pass1");
+    REQUIRE(loaded["github"].username == "user2");
+    REQUIRE(loaded["github"].password == "pass2");
+
+    // Clean up
+    fs::remove(testFile);
+}


### PR DESCRIPTION
This PR sets up the initial unit testing environment using Catch2 v3 and adds basic tests for VaultManager and CredentialManager.
Minor interface updates were made to improve architecture and testability.

**Highlights**

- Added Catch2 v3 as a submodule in thirdparty/.
- Added separate CMake setup for unit tests.
- Implemented initial tests for VaultManager and CredentialManager.
- Improved interfaces for smoother testing integration.

Closes #1